### PR TITLE
kv: implement append-only log with checksum-based recovery

### DIFF
--- a/src/kv/log.rs
+++ b/src/kv/log.rs
@@ -1,0 +1,89 @@
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufReader, Read};
+
+const HEADER_LEN: usize = 12;
+const TOMBSTONE: u32 = u32::MAX;
+
+/// Encodes a single log entry into a flat byte buffer.
+/// `value = None` writes a delete tombstone.
+pub(super) fn encode(key: &[u8], value: Option<&[u8]>) -> Vec<u8> {
+    let klen = key.len() as u32;
+    let vlen = value.map(|v| v.len() as u32).unwrap_or(TOMBSTONE);
+    let vbytes = value.unwrap_or(&[]);
+
+    let mut hasher = crc32fast::Hasher::new();
+    hasher.update(&klen.to_le_bytes());
+    hasher.update(&vlen.to_le_bytes());
+    hasher.update(key);
+    hasher.update(vbytes);
+
+    let mut buf = Vec::with_capacity(HEADER_LEN + key.len() + vbytes.len());
+    buf.extend_from_slice(&hasher.finalize().to_le_bytes());
+    buf.extend_from_slice(&klen.to_le_bytes());
+    buf.extend_from_slice(&vlen.to_le_bytes());
+    buf.extend_from_slice(key);
+    buf.extend_from_slice(vbytes);
+    buf
+}
+
+/// Replays all valid entries from `file` into `index`.
+/// Returns the byte offset just past the last valid entry; any bytes beyond
+/// that are corrupt or truncated and should be discarded with `set_len`.
+pub(super) fn replay(file: &File, index: &mut HashMap<Vec<u8>, Vec<u8>>) -> io::Result<u64> {
+    let mut reader = BufReader::new(file);
+    let mut good_pos: u64 = 0;
+    let mut header = [0u8; HEADER_LEN];
+
+    loop {
+        if !fill(&mut reader, &mut header)? {
+            break;
+        }
+
+        let stored_crc = u32_le(&header[0..]);
+        let klen = u32_le(&header[4..]) as usize;
+        let vlen_raw = u32_le(&header[8..]);
+        let is_delete = vlen_raw == TOMBSTONE;
+        let vlen = if is_delete { 0 } else { vlen_raw as usize };
+
+        let mut body = vec![0u8; klen + vlen];
+        if !fill(&mut reader, &mut body)? {
+            break;
+        }
+
+        let mut hasher = crc32fast::Hasher::new();
+        hasher.update(&header[4..]);
+        hasher.update(&body);
+        if hasher.finalize() != stored_crc {
+            break;
+        }
+
+        let key = body[..klen].to_vec();
+        if is_delete {
+            index.remove(&key);
+        } else {
+            index.insert(key, body[klen..].to_vec());
+        }
+        good_pos += (HEADER_LEN + klen + vlen) as u64;
+    }
+
+    Ok(good_pos)
+}
+
+/// Reads a little-endian `u32` from the start of `src`.
+fn u32_le(src: &[u8]) -> u32 {
+    u32::from_le_bytes(src[..4].try_into().unwrap())
+}
+
+/// Fills `buf` entirely from `reader`.
+/// Returns `false` on EOF (whether clean or mid-entry — both mean stop replaying).
+fn fill<R: Read>(reader: &mut R, buf: &mut [u8]) -> io::Result<bool> {
+    let mut total = 0;
+    while total < buf.len() {
+        match reader.read(&mut buf[total..])? {
+            0 => return Ok(false),
+            n => total += n,
+        }
+    }
+    Ok(true)
+}

--- a/src/kv/mod.rs
+++ b/src/kv/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod file;
+mod log;
 mod store;
 
 pub use store::KV;

--- a/src/kv/store.rs
+++ b/src/kv/store.rs
@@ -1,1 +1,48 @@
-pub struct KV {}
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{self, Write};
+use std::path::Path;
+
+use super::log as kv_log;
+
+#[derive(Debug)]
+pub struct KV {
+    index: HashMap<Vec<u8>, Vec<u8>>,
+    log: File,
+}
+
+impl KV {
+    pub fn open(path: &Path) -> io::Result<Self> {
+        let log = OpenOptions::new()
+            .read(true)
+            .append(true)
+            .create(true)
+            .open(path)?;
+
+        let mut index = HashMap::new();
+        let good_pos = kv_log::replay(&log, &mut index)?;
+        log.set_len(good_pos)?;
+
+        Ok(KV { index, log })
+    }
+
+    pub fn get(&self, key: impl AsRef<[u8]>) -> Option<Vec<u8>> {
+        self.index.get(key.as_ref()).cloned()
+    }
+
+    pub fn set(&mut self, key: impl AsRef<[u8]>, value: impl AsRef<[u8]>) -> io::Result<()> {
+        let (key, value) = (key.as_ref(), value.as_ref());
+        self.log.write_all(&kv_log::encode(key, Some(value)))?;
+        self.log.sync_all()?;
+        self.index.insert(key.to_vec(), value.to_vec());
+        Ok(())
+    }
+
+    pub fn delete(&mut self, key: impl AsRef<[u8]>) -> io::Result<()> {
+        let key = key.as_ref();
+        self.log.write_all(&kv_log::encode(key, None))?;
+        self.log.sync_all()?;
+        self.index.remove(key);
+        Ok(())
+    }
+}

--- a/testdata/kv/log
+++ b/testdata/kv/log
@@ -1,1 +1,40 @@
-# Placeholder — commands will be added as the implementation grows.
+open
+----
+ok
+
+set foo bar
+----
+ok
+
+set baz qux
+----
+ok
+
+get foo
+----
+bar
+
+get baz
+----
+qux
+
+delete foo
+----
+ok
+
+get foo
+----
+(not found)
+
+# Reopen and verify state is recovered from the on-disk log.
+open
+----
+ok
+
+get baz
+----
+qux
+
+get foo
+----
+(not found)

--- a/tests/datadriven.rs
+++ b/tests/datadriven.rs
@@ -1,4 +1,3 @@
-use byodb::testutil;
 use datatest_stable::harness;
 
 fn run(path: &std::path::Path) -> datatest_stable::Result<()> {
@@ -7,7 +6,7 @@ fn run(path: &std::path::Path) -> datatest_stable::Result<()> {
     let module = rel.iter().next().and_then(|s| s.to_str()).unwrap_or("");
 
     match module {
-        "kv" => testutil::run_test(path, kv::run),
+        "kv" => kv::run_file(path),
         other => panic!("unknown test module: {other}"),
     }
 
@@ -15,11 +14,49 @@ fn run(path: &std::path::Path) -> datatest_stable::Result<()> {
 }
 
 mod kv {
+    use byodb::kv::KV;
     use byodb::testutil::Record;
+    use std::cell::RefCell;
+    use std::path::{Path, PathBuf};
 
-    pub fn run(r: &Record) -> String {
+    pub fn run_file(path: &Path) {
+        let dir = std::env::temp_dir()
+            .join("byodb-test")
+            .join(path.file_stem().unwrap_or_default());
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let db_path: PathBuf = dir.join("db");
+
+        let kv: RefCell<Option<KV>> = RefCell::new(None);
+        byodb::testutil::run_test(path, |r| run(r, &kv, &db_path));
+    }
+
+    fn run(r: &Record, kv: &RefCell<Option<KV>>, db_path: &Path) -> String {
         match r.cmd.as_str() {
-            // Commands will be added as the kv implementation grows.
+            "open" => {
+                *kv.borrow_mut() = Some(KV::open(db_path).unwrap());
+                "ok".to_string()
+            }
+            "set" => {
+                kv.borrow_mut()
+                    .as_mut()
+                    .unwrap()
+                    .set(&r.args[0], &r.args[1])
+                    .unwrap();
+                "ok".to_string()
+            }
+            "get" => match kv.borrow().as_ref().unwrap().get(&r.args[0]) {
+                Some(v) => String::from_utf8(v).unwrap(),
+                None => "(not found)".to_string(),
+            },
+            "delete" => {
+                kv.borrow_mut()
+                    .as_mut()
+                    .unwrap()
+                    .delete(&r.args[0])
+                    .unwrap();
+                "ok".to_string()
+            }
             other => panic!("unknown command: {other}"),
         }
     }


### PR DESCRIPTION
Adds a persistent KV store backed by an append-only log file. Each set/delete appends a CRC32-checksummed binary entry and fsyncs. On open, the log is replayed to rebuild the in-memory index; any corrupt or truncated tail is discarded via ftruncate before accepting new writes.